### PR TITLE
 #44-Added unit tests

### DIFF
--- a/sdk/tests/ut_models/test_model.py
+++ b/sdk/tests/ut_models/test_model.py
@@ -1,0 +1,44 @@
+import unittest
+from sdk.models import Model
+
+
+class TestModel(unittest.TestCase):
+    def test_init(self):
+        # Arrange
+        model_name = "test_model"
+        model_path = "/path/to/model"
+
+        # Act
+        model = Model(model_name, model_path)
+
+        # Assert
+        self.assertEqual(model.model_name, model_name)
+        self.assertEqual(model.model_path, model_path)
+
+    def test_load_model_abstract_method(self):
+        # Arrange
+        model = Model("test_model", "/path/to/model")
+
+        # Act & Assert
+        with self.assertRaises(NotImplementedError):
+            model.load_model()
+
+    def test_unload_model_abstract_method(self):
+        # Arrange
+        model = Model("test_model", "/path/to/model")
+
+        # Act & Assert
+        with self.assertRaises(NotImplementedError):
+            model.unload_model()
+
+    def test_generate_prompt_abstract_method(self):
+        # Arrange
+        model = Model("test_model", "/path/to/model")
+
+        # Act & Assert
+        with self.assertRaises(NotImplementedError):
+            model.generate_prompt("test_prompt")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/tests/ut_models/test_model_diffusers.py
+++ b/sdk/tests/ut_models/test_model_diffusers.py
@@ -1,0 +1,136 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from sdk import ModelDiffusers
+from sdk.options import Devices
+
+
+class TestModelDiffusers(unittest.TestCase):
+    def setUp(self):
+        # Set up mock objects and parameters
+        self.model_name = "test_model"
+        self.model_path = "/path/to/model"
+        self.model_class_mock = MagicMock()
+        self.device = "cpu"
+        self.kwargs = {"param1": "value1", "param2": "value2"}
+
+    def test_unload_model_when_loaded(self):
+        # Arrange
+        pipeline_mock = MagicMock()
+        instance = ModelDiffusers(self.model_name, self.model_path,
+                                  self.model_class_mock, self.device,
+                                  **self.kwargs)
+        instance.loaded = True
+        instance.pipeline = pipeline_mock
+
+        # Act
+        result = instance.unload_model()
+
+        # Assert
+        self.assertTrue(result)
+        self.assertFalse(instance.loaded)
+        pipeline_mock.to.assert_called_once_with(device=Devices.RESET.value)
+
+    def test_unload_model_when_not_loaded(self):
+        # Arrange
+        instance = ModelDiffusers(self.model_name, self.model_path,
+                                  self.model_class_mock,
+                                  self.device, **self.kwargs)
+        instance.loaded = False
+
+        # Act
+        result = instance.unload_model()
+
+        # Assert
+        self.assertFalse(result)
+        self.assertFalse(instance.loaded)
+
+    def test_load_model_when_loaded(self):
+        # Arrange
+        instance = ModelDiffusers(self.model_name, self.model_path,
+                                  self.model_class_mock, Devices.CPU,
+                                  **self.kwargs)
+        instance.loaded = True
+
+        # Act
+        result = instance.load_model()
+
+        # Assert
+        self.assertTrue(result)
+        self.assertTrue(instance.loaded)
+
+    def test_load_model_on_reset_device(self):
+        # Arrange
+        instance = ModelDiffusers(self.model_name, self.model_path,
+                                  self.model_class_mock, Devices.RESET,
+                                  **self.kwargs)
+
+        # Act
+        result = instance.load_model()
+
+        # Assert
+        self.assertFalse(result)
+        self.assertFalse(instance.loaded)
+
+    def test_load_model_successfully(self):
+        # Arrange
+        pipeline_mock = MagicMock()
+        instance = ModelDiffusers(self.model_name, self.model_path,
+                                  self.model_class_mock, Devices.CPU,
+                                  **self.kwargs)
+        instance.pipeline = pipeline_mock
+
+        # Act
+        result = instance.load_model()
+
+        # Assert
+        self.assertTrue(result)
+        self.assertTrue(instance.loaded)
+        pipeline_mock.to.assert_called_once_with(device=Devices.CPU.value)
+
+    @patch("sdk.models.ModelDiffusers.unload_model", return_value=True)
+    def test_unload_model(self, mock_unload_model):
+        # Create an instance of ModelDiffusers
+        model = ModelDiffusers(
+            model_name="TestModel",
+            model_path="test/path",
+            device=Devices.GPU,
+            model_class=MagicMock()
+        )
+
+        # Call unload_model method
+        result = model.unload_model()
+
+        # Assert that the model is unloaded
+        self.assertTrue(result)
+        mock_unload_model.assert_called_once()
+
+    def test_generate_prompt(self):
+        # Arrange
+        prompt = "test_prompt"
+        pipeline_mock = MagicMock()
+
+        # Create an instance of ModelsTextToImage
+        # and set the pipeline attribute
+        instance = ModelDiffusers(self.model_name, self.model_path,
+                                  self.model_class_mock,
+                                  self.device, **self.kwargs)
+        instance.pipeline = pipeline_mock
+
+        # Act
+        instance.generate_prompt(prompt)
+
+        # Assert
+        pipeline_mock.assert_called_once()
+
+    def test_create_pipeline(self):
+        # Act
+        instance = ModelDiffusers(
+            self.model_name, self.model_path,
+            self.model_class_mock, self.device, **self.kwargs
+        )
+        # Assert
+        self.assertIsNotNone(instance.pipeline)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/tests/ut_models/test_model_management.py
+++ b/sdk/tests/ut_models/test_model_management.py
@@ -1,0 +1,201 @@
+import unittest
+from typing import Optional, Dict
+from unittest.mock import MagicMock, patch
+from sdk import Model
+from sdk import ModelsManagement
+
+
+class TestModelsManagement(unittest.TestCase):
+    def setUp(self):
+        # Set up mock objects and parameters
+        self.model_name = "test_model"
+        self.model_path = "test_model"
+        self.model_instance_mock = MagicMock(spec=Model)
+        self.loaded_model: Optional[Model] = MagicMock()
+        self.loaded_models_cache: Dict[str, Model] = {}
+
+    def test_add_model(self):
+        instance = ModelsManagement()
+        # Arrange
+        instance.loaded_models_cache = {}  # Clear existing cache
+        # Create a mock object with model_name attribute
+        self.model_instance_mock =\
+            MagicMock(model_name=self.model_name)
+        instance.loaded_models_cache[self.model_name] \
+            = self.model_instance_mock
+
+        # Act
+        result = instance.add_model(self.model_instance_mock)
+
+        # Assert
+        self.assertFalse(result)  # Model already exists in cache
+        self.assertEqual(len(instance.loaded_models_cache),
+                         1)
+
+    def test_add_model_success(self):
+        instance = ModelsManagement()
+        # Arrange
+        instance.loaded_models_cache = {}  # Clear existing cache
+        # Create a mock object with model_name attribute
+        self.model_instance_mock = MagicMock(
+            model_name=self.model_name
+        )
+
+        # Act
+        result = instance.add_model(self.model_instance_mock)
+
+        # Assert
+        self.assertTrue(result)  # Model already exists in cache
+        self.assertEqual(len(instance.loaded_models_cache), 1)
+
+    def test_load_model_unsuccessful_cache(self):
+        # Arrange
+        instance = ModelsManagement()
+        model_name = self.model_name
+        instance.loaded_model = {}
+        # Act
+        result = instance.load_model(model_name)
+
+        # Assert
+        self.assertFalse(result)
+
+    def test_load_model_unsuccessful_loaded(self):
+        # Arrange
+        instance = ModelsManagement()
+        model_name = self.model_name
+        instance.loaded_model = True
+
+        # Act
+        result = instance.load_model(model_name)
+
+        # Assert
+        self.assertFalse(result)
+
+    @patch("sdk.models.Model.load_model",
+           side_effect=NotImplementedError)
+    def test_load_model_unsuccessful_loaded_error(self, mock_load_model):
+        # Arrange
+        instance = ModelsManagement()
+        instance.loaded_model = False
+        model_name = "your_model_name"
+        instance.loaded_models_cache[model_name] = MagicMock()
+
+        # Act
+        result = instance.load_model(model_name)
+
+        # Assert
+        self.assertTrue(result)
+
+    @patch("sdk.models.ModelsManagement.unload_model")
+    def test_generate_prompt_without_model_name(self, unload_model_mock):
+        # Arrange
+        prompt = "test_prompt"
+        instance = ModelsManagement()
+
+        # Create a mock object with model_name attribute
+        self.model_instance_mock = MagicMock(model_name=None)
+        instance.add_model(self.model_instance_mock)
+        instance.loaded_model = self.model_instance_mock
+        instance.loaded_model.model_name = 'rand'
+        # Act
+        instance.generate_prompt(prompt)
+
+        # Assert
+        unload_model_mock.assert_not_called()
+
+    @patch("sdk.models.ModelsManagement.load_model")
+    @patch("sdk.models.ModelsManagement.unload_model")
+    def test_generate_prompt_with_model_name(self, unload_model_mock,
+                                             load_model_mock):
+        # Arrange
+        prompt = "test_prompt"
+        instance = ModelsManagement()
+        self.model_instance_mock = MagicMock(model_name="",
+                                             name=self.model_path,
+                                             class_name=MagicMock(),
+                                             module=MagicMock())
+        # Create mock objects with model_name attributes
+        instance.add_model(self.model_instance_mock)
+        instance.loaded_model = self.model_instance_mock
+
+        # Act
+        instance.generate_prompt(prompt, "tester")
+
+        # Assert
+        unload_model_mock.assert_called_once()
+
+    def test_unload_model_success(self):
+        # Arrange
+        instance = ModelsManagement()
+        self.model_instance_mock = MagicMock(model_name=self.model_name,
+                                             name=self.model_path,
+                                             class_name=MagicMock(),
+                                             module=MagicMock())
+        instance.add_model(self.model_instance_mock)
+        instance.loaded_model = self.model_instance_mock
+
+        # Act
+        result = instance.unload_model()
+
+        # Assert
+        self.assertTrue(result)  # Ensure that unload_model
+        # returns True when model is successfully unloaded
+        self.assertIsNone(instance.loaded_model)  # Ensure that loaded_model
+        # is set to None after unloading
+
+    def test_unload_model_failure(self):
+        # Arrange
+        instance = ModelsManagement()
+        self.model_instance_mock = MagicMock(model_name=self.model_name,
+                                             name=self.model_path,
+                                             class_name=MagicMock(),
+                                             module=MagicMock())
+        self.model_instance_mock.unload_model.return_value = False
+        instance.add_model(self.model_instance_mock)
+        instance.loaded_model = self.model_instance_mock
+
+        # Act
+        result = instance.unload_model()
+
+        # Assert
+        # Ensure that unload_model returns False when model
+        # is unsuccessfully unloaded
+        self.assertFalse(result)
+        # Ensure that loaded_model is set and not unloaded
+        self.assertEqual(len(instance.loaded_models_cache),
+                         1)
+
+    def test_unload_loaded_model_failure(self):
+        # Arrange
+        instance = ModelsManagement()
+        instance.loaded_model = None
+
+        # Act
+        result = instance.unload_model()
+
+        # Assert
+        self.assertFalse(result)  # Ensure that unload_model returns
+        # False when model is unsuccessfully unloaded
+
+    def test_print_models(self):
+        # Arrange
+        instance = ModelsManagement()
+        instance.loaded_models_cache = {
+            "model1": MagicMock(spec=Model),
+            "model2": MagicMock(spec=Model)
+        }
+        instance.loaded_model = instance.loaded_models_cache["model1"]
+
+        # Act
+        with patch("builtins.print") as mocked_print:
+            instance.print_models()
+
+        # Assert
+        expected_output = (
+            "- model2 "
+        )
+        mocked_print.assert_called_with(expected_output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/tests/ut_models/test_model_text_conversation.py
+++ b/sdk/tests/ut_models/test_model_text_conversation.py
@@ -1,0 +1,166 @@
+import unittest
+from unittest.mock import MagicMock, patch
+from sdk.models import ModelsTextConversation
+from transformers import Conversation
+
+import uuid
+
+
+class TestModelsTextConversation(unittest.TestCase):
+    def setUp(self):
+        self.model_name = "test_model"
+        self.model_path = "/path/to/model"
+        self.tokenizer_path = "/path/to/tokenizer"
+        self.model_class_mock = MagicMock()
+        self.tokenizer_class_mock = MagicMock()
+        self.device = "gpu"
+        self.kwargs = {"param1": "value1", "param2": "value2"}
+        self.transformers_pipeline = MagicMock()
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_init(self, create_pipeline_mock):
+        instance = ModelsTextConversation(
+            model_name=self.model_name, model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            tokenizer_class=self.tokenizer_class_mock,
+            model_class=self.model_class_mock, device=self.device
+        )
+        instance.transformers_pipeline = MagicMock()
+
+        # Assert
+        self.assertEqual(instance.model_name, self.model_name)
+        self.assertEqual(instance.model_path, self.model_path)
+        self.assertEqual(instance.model_class, self.model_class_mock)
+        self.assertEqual(instance.tokenizer_class, self.tokenizer_class_mock)
+        self.assertEqual(instance.device, self.device)
+        create_pipeline_mock.assert_called_once()
+
+    @patch("sdk.ModelsTextConversation.create_pipeline")
+    @patch("sdk.ModelsTextConversation.write_input", return_value=None)
+    def test_generate_prompt(self, write_input_mock,
+                             pipeline_mock):
+        # Arrange
+        prompt = "test_prompt"
+
+        instance = ModelsTextConversation(
+            model_name=self.model_name, model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            tokenizer_class=self.tokenizer_class_mock,
+            model_class=self.model_class_mock, device=self.device
+        )
+        instance.transformers_pipeline = MagicMock()
+        instance.conversation = MagicMock()
+
+        # Act
+        result = instance.generate_prompt(prompt)
+
+        # Assert
+        write_input_mock.assert_called_once_with(prompt)
+        pipeline_mock.assert_called_once_with()
+        self.assertIsNotNone(result)  # Assert that result is not None
+
+    @patch("sdk.ModelsTextConversation.create_pipeline")
+    def test_write_input(self, pipeline_mock):
+        # Arrange
+        prompt = "test_prompt"
+        instance = ModelsTextConversation(
+            model_name=self.model_name, model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            tokenizer_class=self.tokenizer_class_mock,
+            model_class=self.model_class_mock, device=self.device
+        )
+        instance.transformers_pipeline = MagicMock()
+        conversation_mock = MagicMock()
+
+        instance.conversation = conversation_mock
+
+        # Act
+        instance.write_input(prompt)
+
+        # Assert
+        pipeline_mock.assert_called_once()
+        conversation_mock.add_message.assert_called_once_with(
+            {"role": "user", "content": prompt}
+        )
+
+    @patch("sdk.ModelsTextConversation.create_pipeline")
+    def test_create_new_conversation(self, pipeline_mock):
+        # Arrange
+        instance = ModelsTextConversation(
+            model_name=self.model_name, model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            tokenizer_class=self.tokenizer_class_mock,
+            model_class=self.model_class_mock, device=self.device
+        )
+        instance.transformers_pipeline = MagicMock()
+        instance.conversation = Conversation()
+
+        # Act
+        instance.create_new_conversation()
+
+        # Assert
+        pipeline_mock.assert_called_once()
+        self.assertIsInstance(instance.conversation, Conversation)
+        self.assertIn(instance.conversation.uuid,
+                      instance.conversation_dict)
+
+    @patch("sdk.ModelsTextConversation.create_pipeline")
+    def test_change_conversation_valid_id(self, pipeline_mock):
+        # Arrange
+
+        # Arrange
+        instance = ModelsTextConversation(
+            model_name=self.model_name, model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            tokenizer_class=self.tokenizer_class_mock,
+            model_class=self.model_class_mock, device=self.device
+        )
+        instance.transformers_pipeline = MagicMock()
+        instance.conversation = Conversation()
+        instance.create_new_conversation()
+
+        conversation_one = instance.conversation  # Conversation to fetch
+        conv_id = conversation_one.uuid
+
+        instance.create_new_conversation()
+        instance.create_new_conversation()
+
+        # Act
+        result = instance.change_conversation(conv_id)
+
+        # Assert
+        pipeline_mock.assert_called_once()
+        self.assertTrue(result)
+        self.assertEqual(instance.conversation, conversation_one)
+
+    @patch("sdk.ModelsTextConversation.create_pipeline")
+    def test_change_conversation_invalid_id(self, pipeline_mock):
+        # Arrange
+
+        # Arrange
+        instance = ModelsTextConversation(
+            model_name=self.model_name, model_path=self.model_path,
+            tokenizer_path=self.tokenizer_path,
+            tokenizer_class=self.tokenizer_class_mock,
+            model_class=self.model_class_mock, device=self.device
+        )
+        instance.transformers_pipeline = MagicMock()
+        instance.conversation = Conversation()
+        instance.create_new_conversation()
+
+        # Act
+        # Random UUID value
+        uuid_value = '123e4567-e89b-12d3-a456-426614174000'
+
+        # Create a UUID object from the specified value
+        custom_uuid = uuid.UUID(uuid_value)
+
+        result = instance.change_conversation(custom_uuid)
+
+        # Assert
+        pipeline_mock.assert_called_once()
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/tests/ut_models/test_model_transformers.py
+++ b/sdk/tests/ut_models/test_model_transformers.py
@@ -1,0 +1,271 @@
+import unittest
+import torch
+from unittest.mock import MagicMock, patch
+from sdk import ModelTransformers, Devices
+
+
+class TestModelTransformers(unittest.TestCase):
+    def setUp(self):
+        # Set up mock objects and parameters
+        self.model_name = "test_model"
+        self.model_path = "/path/to/model"
+        self.tokenizer_path = "/path/to/tokenizer"
+        self.task = "text-generation"
+        self.model_class_mock = MagicMock()
+        self.tokenizer_class_mock = MagicMock()
+        self.device = "cpu"
+        self.kwargs = {"param1": "value1", "param2": "value2"}
+        self.transformers_pipeline = MagicMock()
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_init(self, create_pipeline_mock):
+        # Arrange
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+
+        # Assert
+        self.assertEqual(instance.model_name, self.model_name)
+        self.assertEqual(instance.model_path, self.model_path)
+        self.assertEqual(instance.tokenizer_path, self.tokenizer_path)
+        self.assertEqual(instance.task, self.task)
+        self.assertEqual(instance.model_class, self.model_class_mock)
+        self.assertEqual(instance.tokenizer_class,
+                         self.tokenizer_class_mock)
+        self.assertEqual(instance.device, self.device)
+        self.assertFalse(instance.loaded)
+        create_pipeline_mock.assert_called_once()
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_load_model_when_loaded(self, create_pipeline_mock):
+        # Arrange
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        instance.loaded = True
+
+        # Act
+        result = instance.load_model()
+
+        # Assert
+        self.assertTrue(result)
+        self.assertTrue(instance.loaded)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_load_model_when_device_meta(self, create_pipeline_mock):
+        # Arrange
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        instance.loaded = False
+        instance.transformers_pipeline = MagicMock()
+        instance.transformers_pipeline.device = (
+            torch.device(Devices.RESET.value)
+        )
+
+        # Act
+        result = instance.load_model()
+
+        # Assert
+        self.assertTrue(result)
+        self.assertTrue(instance.loaded)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_load_model_on_reset_device(self, create_pipeline_mock):
+        # Arrange
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, Devices.RESET.value
+        )
+
+        # Act
+        result = instance.load_model()
+
+        # Assert
+        self.assertFalse(result)
+        self.assertFalse(instance.loaded)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_load_model_successfully(self, create_pipeline_mock):
+        # Arrange
+        pipeline_mock = MagicMock()
+        create_pipeline_mock.return_value = None
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        instance.transformers_pipeline = pipeline_mock
+
+        # Act
+        result = instance.load_model()
+
+        # Assert
+        self.assertTrue(result)
+        self.assertTrue(instance.loaded)
+        pipeline_mock.model.to.assert_called_once_with(device='cpu')
+
+    @patch("torch.cuda.empty_cache")
+    @patch("torch.cuda.ipc_collect")
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_unload_model_when_loaded(self, create_pipeline_mock,
+                                      mock_ipc_collect, mock_empty_cache):
+        # Arrange
+        pipeline_mock = MagicMock()
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        instance.loaded = True
+        instance.transformers_pipeline = MagicMock(
+            return_value=pipeline_mock
+        )
+
+        # Act
+        result = instance.unload_model()
+
+        # Assert
+        self.assertTrue(result)
+        self.assertFalse(instance.loaded)
+        mock_ipc_collect.assert_called_once()
+        mock_empty_cache.assert_called_once()
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_unload_model_when_not_loaded(self, create_pipeline_mock):
+        # Arrange
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        instance.loaded = False
+
+        # Act
+        result = instance.unload_model()
+
+        # Assert
+        self.assertFalse(result)
+        self.assertFalse(instance.loaded)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_generate_prompt(self, create_pipeline_mock):
+        # Arrange
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        instance.transformers_pipeline = MagicMock()
+
+        # Act
+        result = instance.generate_prompt("test_prompt")
+
+        # Assert
+        self.assertEqual(result, instance.transformers_pipeline.return_value)
+
+    # def test_create_pipeline_loaded(self):
+    #     # Arrange
+    #     instance = ModelTransformers(
+    #         self.model_name, self.model_path, self.tokenizer_path,
+    #         self.task, pipeline, self.tokenizer_class_mock, self.device
+    #     )
+    #     # Assert
+    #     self.assertIsNotNone(instance.transformers_pipeline)
+    # def test_create_pipeline(self):
+    #     # Arrange
+    #     instance = ModelTransformers(
+    #         self.model_name, self.model_path, self.tokenizer_path,
+    #         self.task, pipeline, self.tokenizer_class_mock, self.device
+    #     )
+    #
+    #     # Assert
+    #     self.assertIsNotNone(instance.transformers_pipeline)
+
+    # @patch("transformers.pipeline")
+    # def test_create_pipeline_successfully(self, mock_pipeline):
+    #
+    #     # Act
+    #     instance = ModelTransformers(
+    #         self.model_name, self.model_path, self.tokenizer_path,
+    #         self.task, pipeline_mock, self.tokenizer_class_mock, self.device,
+    #     )
+    #     # Assert
+    #     self.assertIsNotNone(instance.tokenizer_pipeline)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_set_model_pipeline_args(self, mock):
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        # Arrange
+        kwargs = {"arg1": "value1", "arg2": "value2"}
+
+        # Act
+        instance.set_model_pipeline_args(**kwargs)
+
+        # Assert
+        self.assertEqual(instance.model_pipeline_args, kwargs)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_set_model_pipeline_args_empty(self, mock):
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        # Arrange
+        initial_args = {"initial_arg": "initial_value"}
+        instance.model_pipeline_args = initial_args.copy()
+
+        # Act
+        instance.set_model_pipeline_args()
+
+        # Assert
+        self.assertEqual(instance.model_pipeline_args, initial_args)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_set_tokenizer_pipeline_args(self, mock):
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        # Arrange
+        kwargs = {"arg1": "value1", "arg2": "value2"}
+
+        # Act
+        instance.set_tokenizer_pipeline_args(**kwargs)
+
+        # Assert
+        self.assertEqual(instance.tokenizer_pipeline_args, kwargs)
+
+    @patch("sdk.ModelTransformers.create_pipeline")
+    def test_set_tokenizer_pipeline_args_empty(self, mock):
+        instance = ModelTransformers(
+            self.model_name, self.model_path, self.tokenizer_path,
+            self.task, self.model_class_mock,
+            self.tokenizer_class_mock, self.device
+        )
+        # Arrange
+        initial_args = {"initial_arg": "initial_value"}
+        instance.tokenizer_pipeline_args = initial_args.copy()
+
+        # Act
+        instance.set_tokenizer_pipeline_args()
+
+        # Assert
+        self.assertEqual(instance.tokenizer_pipeline_args, initial_args)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/tests/ut_options/test_options_tokenizer.py
+++ b/sdk/tests/ut_options/test_options_tokenizer.py
@@ -1,0 +1,33 @@
+import unittest
+from sdk import Devices
+from sdk.options.options_tokenizer import OptionsTokenizer
+
+
+class TestOptionsTokenizer(unittest.TestCase):
+    def test_init_defaults(self):
+        options = OptionsTokenizer(device="cpu", padding_side=None,
+                                   return_tensors=None)
+        self.assertEqual(options.device, "cpu")
+        self.assertEqual(options.padding_side, "left")
+        self.assertIsNone(options.return_tensors)
+
+    def test_init_custom(self):
+        options = OptionsTokenizer(device=Devices.CPU, padding_side="right",
+                                   return_tensors="tf")
+        self.assertEqual(options.device, Devices.CPU)
+        self.assertEqual(options.padding_side, "right")
+        self.assertEqual(options.return_tensors, "tf")
+
+    def test_invalid_padding_side(self):
+        with self.assertRaises(ValueError):
+            OptionsTokenizer(device="cuda", padding_side="invalid",
+                             return_tensors=None)
+
+    def test_padding_side_default(self):
+        options = OptionsTokenizer(device="cuda", padding_side=None,
+                                   return_tensors=None)
+        self.assertEqual(options.padding_side, "left")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
I am still having trouble testing the create pipeline method for transformer models, for some reason I am unable to patch the from_pretrained calls :
```
self.model_pipeline = self.model_class.from_pretrained(
            self.model_path,
            **self.model_pipeline_args
        )

        self.tokenizer_pipeline = self.tokeniser_class.from_pretrained(
            self.tokenizer_path,
            **self.tokenizer_pipeline_args
        )
```